### PR TITLE
Gemfile example missing colon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The nature of `Capybara::Maleficent` is such that most of the time the matching 
 In you Gemfile:
 
 ```ruby
-gem 'capybara-maleficent', require 'false'
+gem 'capybara-maleficent', require: 'false'
 ```
 
 In your `spec/spec_helper.rb`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The nature of `Capybara::Maleficent` is such that most of the time the matching 
 In you Gemfile:
 
 ```ruby
-gem 'capybara-maleficent', require: 'false'
+gem 'capybara-maleficent', require: false
 ```
 
 In your `spec/spec_helper.rb`


### PR DESCRIPTION
This currently results in:

```
[!] There was an error parsing `Gemfile`: syntax error, unexpected tSTRING_BEG, expecting keyword_do or '{' or '(' -   gem 'capybara-maleficent', require 'false'
                                      ^. Bundler cannot continue.
```