### PR TITLE
Allow 3.x capybara

### DIFF
--- a/capybara-maleficent.gemspec
+++ b/capybara-maleficent.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version      = '>= 2.2.2'
 
   spec.add_dependency "activesupport", ">= 4.2.0"
-  spec.add_dependency "capybara", "~> 2.13"
+  spec.add_dependency "capybara", ">= 2.13", "< 4.0"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Relax capybara dependency to allow for 3.x versions of capybara in order to update `chromedriver-helper`.
This is blocking https://github.com/samvera/hyrax/pull/3314.